### PR TITLE
Self reg slaves support

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/CloudEntityVerificationException.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/CloudEntityVerificationException.java
@@ -1,0 +1,11 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+/**
+ * @author <a href="mailto:kirill.shepitko@gmail.com">Kirill Shepitko</a>
+ */
+public class CloudEntityVerificationException extends RuntimeException {
+
+    public CloudEntityVerificationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -1025,7 +1025,7 @@ public class KubernetesCloud extends Cloud {
 
         if (namedListItems != null && slaveListItems != null && template.getInstanceCap() <= namedListItems.size()) {
             LOGGER.log(Level.INFO,
-                    "Template instance cap of {0} reached for template {1}, not provisioning: {2} running in namespace '{3}' with label '{4}'",
+                    "Template instance cap of {0} reached for template {1}, not provisioning: {2} running in namespace {3} with label {4}",
                     new Object[] { template.getInstanceCap(), template.getName(), slaveListItems.size(),
                             client.getNamespace(), label == null ? "" : label.toString() });
             return false; // maxed out

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudUtils.java
@@ -1,6 +1,7 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
 import hudson.slaves.Cloud;
+import jenkins.model.Jenkins;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -10,11 +11,15 @@ import static java.lang.String.format;
 /**
  * @author <a href="mailto:kirill.shepitko@gmail.com">Kirill Shepitko</a>
  */
-public class KubernetesCloudVerifier {
+public class KubernetesCloudUtils {
 
-    private static final Logger LOGGER = Logger.getLogger(KubernetesCloudVerifier.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(KubernetesCloudUtils.class.getName());
 
-    private KubernetesCloudVerifier() {}
+    private KubernetesCloudUtils() {}
+
+    public static KubernetesCloud getCloud(String cloudName) {
+        return (KubernetesCloud) Jenkins.getInstance().getCloud(cloudName);
+    }
 
     public static void checkCloudExistence(Cloud cloud, String expectedCloudName) {
         if (cloud == null) {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudVerifier.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudVerifier.java
@@ -1,0 +1,34 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import hudson.slaves.Cloud;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static java.lang.String.format;
+
+/**
+ * @author <a href="mailto:kirill.shepitko@gmail.com">Kirill Shepitko</a>
+ */
+public class KubernetesCloudVerifier {
+
+    private static final Logger LOGGER = Logger.getLogger(KubernetesCloudVerifier.class.getName());
+
+    private KubernetesCloudVerifier() {}
+
+    public static void checkCloudExistence(Cloud cloud, String expectedCloudName) {
+        if (cloud == null) {
+            String msg = format("Slave cloud no longer exists: %s", expectedCloudName);
+            handleCheckFailure(Level.WARNING, msg);
+        }
+        if (!(cloud instanceof KubernetesCloud)) {
+            String msg = format("Slave cloud %s is not a KubernetesCloud, something is very wrong", expectedCloudName);
+            handleCheckFailure(Level.SEVERE, msg);
+        }
+    }
+
+    private static void handleCheckFailure(Level logLevel, String msg) {
+        LOGGER.log(logLevel, msg);
+        throw new CloudEntityVerificationException(msg);
+    }
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -1,18 +1,6 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
-import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import org.apache.commons.lang.RandomStringUtils;
-import org.apache.commons.lang.StringUtils;
-import org.jenkinsci.plugins.durabletask.executors.OnceRetentionStrategy;
-import org.jvnet.localizer.Localizable;
-import org.jvnet.localizer.ResourceBundleHolder;
-import org.kohsuke.stapler.DataBoundConstructor;
-
 import hudson.Extension;
-import hudson.model.Computer;
 import hudson.model.Descriptor;
 import hudson.model.Label;
 import hudson.model.Node;
@@ -20,13 +8,18 @@ import hudson.model.TaskListener;
 import hudson.slaves.AbstractCloudSlave;
 import hudson.slaves.Cloud;
 import hudson.slaves.JNLPLauncher;
-import hudson.slaves.OfflineCause;
 import hudson.slaves.RetentionStrategy;
-import io.fabric8.kubernetes.api.model.DoneablePod;
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.dsl.PodResource;
 import jenkins.model.Jenkins;
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.durabletask.executors.OnceRetentionStrategy;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static java.lang.String.format;
 
 /**
  * @author Carlos Sanchez carlos@apache.org
@@ -37,11 +30,6 @@ public class KubernetesSlave extends AbstractCloudSlave {
 
     private static final long serialVersionUID = -8642936855413034232L;
     private static final String DEFAULT_AGENT_PREFIX = "jenkins-agent";
-
-    /**
-     * The resource bundle reference
-     */
-    private final static ResourceBundleHolder HOLDER = ResourceBundleHolder.get(Messages.class);
 
     private final String cloudName;
     private final String namespace;
@@ -101,13 +89,13 @@ public class KubernetesSlave extends AbstractCloudSlave {
         String randString = RandomStringUtils.random(5, "bcdfghjklmnpqrstvwxz0123456789");
         String name = template.getName();
         if (StringUtils.isEmpty(name)) {
-            return String.format("%s-%s", DEFAULT_AGENT_PREFIX,  randString);
+            return format("%s-%s", DEFAULT_AGENT_PREFIX,  randString);
         }
         // no spaces
         name = name.replaceAll("[ _]", "-").toLowerCase();
         // keep it under 63 chars (62 is used to account for the '-')
         name = name.substring(0, Math.min(name.length(), 62 - randString.length()));
-        return String.format("%s-%s", name, randString);
+        return format("%s-%s", name, randString);
     }
 
     @Override
@@ -119,52 +107,26 @@ public class KubernetesSlave extends AbstractCloudSlave {
     protected void _terminate(TaskListener listener) throws IOException, InterruptedException {
         LOGGER.log(Level.INFO, "Terminating Kubernetes instance for slave {0}", name);
 
-        Computer computer = toComputer();
-        if (computer == null) {
-            String msg = String.format("Computer for slave is null: %s", name);
-            LOGGER.log(Level.SEVERE, msg);
-            listener.fatalError(msg);
-            return;
-        }
-
-        if (getCloudName() == null) {
-            String msg = String.format("Cloud name is not set for slave, can't terminate: %s", name);
-            LOGGER.log(Level.SEVERE, msg);
-            listener.fatalError(msg);
-            return;
-        }
-
         try {
+            KubernetesSlaveUtils.checkSlaveComputer(this);
+            KubernetesSlaveUtils.checkSlaveCloudName(this);
+
             Cloud cloud = getCloud();
-            if (cloud == null) {
-                String msg = String.format("Slave cloud no longer exists: %s", getCloudName());
-                LOGGER.log(Level.WARNING, msg);
-                listener.fatalError(msg);
-                return;
+            KubernetesCloudVerifier.checkCloudExistence(cloud, getCloudName());
+
+            if (new SlaveTerminator((KubernetesCloud) cloud).terminatePodSlave(this, namespace)) {
+                listener.getLogger().println(format("Terminated Kubernetes instance for slave %s", name));
+            } else {
+                listener.fatalError(format("Failed to terminate pod for slave %s", name));
             }
-            if (!(cloud instanceof KubernetesCloud)) {
-                String msg = String.format("Slave cloud is not a KubernetesCloud, something is very wrong: %s",
-                        getCloudName());
-                LOGGER.log(Level.SEVERE, msg);
-                listener.fatalError(msg);
-                return;
-            }
-            KubernetesClient client = ((KubernetesCloud) cloud).connect();
-            PodResource<Pod, DoneablePod> pods = client.pods().inNamespace(namespace).withName(name);
-            pods.delete();
-            String msg = String.format("Terminated Kubernetes instance for slave %s", name);
-            LOGGER.log(Level.INFO, msg);
-            listener.getLogger().println(msg);
-            computer.disconnect(OfflineCause.create(new Localizable(HOLDER, "offline")));
-            LOGGER.log(Level.INFO, "Disconnected computer {0}", name);
-        } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "Failed to terminate pod for slave " + name, e);
+        } catch(CloudEntityVerificationException e) {
+            listener.fatalError(e.getMessage());
         }
     }
 
     @Override
     public String toString() {
-        return String.format("KubernetesSlave name: %s", name);
+        return format("KubernetesSlave name: %s", name);
     }
 
     @Extension
@@ -173,7 +135,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
         @Override
         public String getDisplayName() {
             return "Kubernetes Slave";
-        };
+        }
 
         @Override
         public boolean isInstantiable() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -112,10 +112,11 @@ public class KubernetesSlave extends AbstractCloudSlave {
             KubernetesSlaveUtils.checkSlaveCloudName(this);
 
             Cloud cloud = getCloud();
-            KubernetesCloudVerifier.checkCloudExistence(cloud, getCloudName());
+            KubernetesCloudUtils.checkCloudExistence(cloud, getCloudName());
 
-            if (new SlaveTerminator((KubernetesCloud) cloud).terminatePodSlave(this, namespace)) {
-                listener.getLogger().println(format("Terminated Kubernetes instance for slave %s", name));
+            SlaveTerminator slaveTerminator = new SlaveTerminator((KubernetesCloud) cloud);
+            if (slaveTerminator.terminatePodSlave(this, namespace)) {
+                listener.getLogger().println(format("Terminated Kubernetes pod for slave %s", name));
             } else {
                 listener.fatalError(format("Failed to terminate pod for slave %s", name));
             }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlaveException.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlaveException.java
@@ -1,0 +1,11 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+/**
+ * @author <a href="mailto:kirill.shepitko@gmail.com">Kirill Shepitko</a>
+ */
+public class KubernetesSlaveException extends RuntimeException {
+
+    public KubernetesSlaveException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlaveUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlaveUtils.java
@@ -1,0 +1,47 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import hudson.model.Computer;
+import hudson.model.Slave;
+import org.apache.commons.lang.StringUtils;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static java.lang.String.format;
+
+/**
+ * @author <a href="mailto:kirill.shepitko@gmail.com">Kirill Shepitko</a>
+ */
+public class KubernetesSlaveUtils {
+
+    private static final Logger LOGGER = Logger.getLogger(KubernetesSlaveUtils.class.getName());
+
+    private KubernetesSlaveUtils() {}
+
+    public static void checkSlaveName(String actualSlaveName, String expectedName) {
+        if (!StringUtils.equals(actualSlaveName, expectedName)) {
+            String msg = format("Slave name was expected to be %s, but is %s", expectedName, actualSlaveName);
+            handleCheckFailure(msg);
+        }
+    }
+
+    public static void checkSlaveComputer(Slave slave) {
+        Computer computer = slave.toComputer();
+        if (computer == null) {
+            String msg = format("Computer for slave %s is null", slave.getNodeName());
+            handleCheckFailure(msg);
+        }
+    }
+
+    public static void checkSlaveCloudName(KubernetesSlave slave) {
+        if (slave.getCloudName() == null) {
+            String msg = format("Cloud name is not set for slave %s, can't terminate", slave.getNodeName());
+            handleCheckFailure(msg);
+        }
+    }
+
+    private static void handleCheckFailure(String msg) {
+        LOGGER.log(Level.SEVERE, msg);
+        throw new CloudEntityVerificationException(msg);
+    }
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/SelfRegisteredSlaveNodeListener.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/SelfRegisteredSlaveNodeListener.java
@@ -1,0 +1,52 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import com.google.common.annotations.VisibleForTesting;
+import hudson.Extension;
+import hudson.model.Node;
+import hudson.slaves.AbstractCloudSlave;
+import hudson.slaves.RetentionStrategy;
+import jenkins.model.NodeListener;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static java.lang.String.format;
+
+/**
+ * @author <a href="mailto:kirill.shepitko@gmail.com">Kirill Shepitko</a>
+ */
+@Extension
+public class SelfRegisteredSlaveNodeListener extends NodeListener {
+
+    private static final Logger LOGGER = Logger.getLogger(SelfRegisteredSlaveNodeListener.class.getName());
+
+    @Override
+    protected void onDeleted(@Nonnull Node node) {
+        LOGGER.log(Level.INFO, "Node {0} was deleted", node);
+        String labelString = node.getLabelString();
+        LOGGER.log(Level.INFO, "Node labels: {0}", labelString);
+
+        if (node instanceof AbstractCloudSlave) {
+            AbstractCloudSlave slave = (AbstractCloudSlave) node;
+            RetentionStrategy retentionStrategy = slave.getRetentionStrategy();
+            if (retentionStrategy != null && retentionStrategy instanceof SelfRegisteredSlaveRetentionStrategy) {
+                String podName = node.getNodeName();
+                LOGGER.log(Level.INFO, "Going to delete pod {0}", podName);
+                try {
+                    // Let's reuse retention strategy, since it's already capable of deleting pods.
+                    kill((SelfRegisteredSlaveRetentionStrategy) retentionStrategy, node);
+                } catch (IOException e) {
+                    LOGGER.log(Level.SEVERE, format("Failed to delete pod %s", podName), e);
+                }
+            }
+        }
+    }
+
+    @VisibleForTesting
+    void kill(SelfRegisteredSlaveRetentionStrategy retentionStrategy, @Nonnull Node node) throws IOException {
+        retentionStrategy.kill(node);
+    }
+
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/SelfRegisteredSlaveNodeListener.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/SelfRegisteredSlaveNodeListener.java
@@ -3,16 +3,13 @@ package org.csanchez.jenkins.plugins.kubernetes;
 import com.google.common.annotations.VisibleForTesting;
 import hudson.Extension;
 import hudson.model.Node;
-import hudson.slaves.AbstractCloudSlave;
+import hudson.model.Slave;
 import hudson.slaves.RetentionStrategy;
 import jenkins.model.NodeListener;
 
 import javax.annotation.Nonnull;
-import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import static java.lang.String.format;
 
 /**
  * @author <a href="mailto:kirill.shepitko@gmail.com">Kirill Shepitko</a>
@@ -24,29 +21,27 @@ public class SelfRegisteredSlaveNodeListener extends NodeListener {
 
     @Override
     protected void onDeleted(@Nonnull Node node) {
-        LOGGER.log(Level.INFO, "Node {0} was deleted", node);
-        String labelString = node.getLabelString();
-        LOGGER.log(Level.INFO, "Node labels: {0}", labelString);
-
-        if (node instanceof AbstractCloudSlave) {
-            AbstractCloudSlave slave = (AbstractCloudSlave) node;
+        LOGGER.log(Level.INFO, "Node {0} (labels - {1}) was deleted", new Object[] {node, node.getLabelString()});
+        if (node instanceof Slave) {
+            Slave slave = (Slave) node;
             RetentionStrategy retentionStrategy = slave.getRetentionStrategy();
             if (retentionStrategy != null && retentionStrategy instanceof SelfRegisteredSlaveRetentionStrategy) {
-                String podName = node.getNodeName();
-                LOGGER.log(Level.INFO, "Going to delete pod {0}", podName);
-                try {
-                    // Let's reuse retention strategy, since it's already capable of deleting pods.
-                    kill((SelfRegisteredSlaveRetentionStrategy) retentionStrategy, node);
-                } catch (IOException e) {
-                    LOGGER.log(Level.SEVERE, format("Failed to delete pod %s", podName), e);
-                }
+                kill((SelfRegisteredSlaveRetentionStrategy) retentionStrategy, slave);
             }
         }
     }
 
     @VisibleForTesting
-    void kill(SelfRegisteredSlaveRetentionStrategy retentionStrategy, @Nonnull Node node) throws IOException {
-        retentionStrategy.kill(node);
+    void kill(SelfRegisteredSlaveRetentionStrategy retentionStrategy, @Nonnull Slave slave) {
+        String podName = slave.getNodeName();
+        LOGGER.log(Level.INFO, "Going to delete pod {0}", podName);
+
+        String cloudName = retentionStrategy.getCloudName();
+        String namespace = retentionStrategy.getNamespace();
+        KubernetesCloud cloud = KubernetesCloudUtils.getCloud(cloudName);
+
+        SlaveTerminator slaveTerminator = new SlaveTerminator(cloud);
+        slaveTerminator.terminatePodSlave(slave, namespace);
     }
 
 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/SelfRegisteredSlaveRetentionStrategy.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/SelfRegisteredSlaveRetentionStrategy.java
@@ -7,7 +7,6 @@ import hudson.model.Slave;
 import hudson.slaves.Cloud;
 import hudson.slaves.CloudSlaveRetentionStrategy;
 import hudson.util.TimeUnit2;
-import jenkins.model.Jenkins;
 
 import java.io.IOException;
 import java.util.logging.Level;
@@ -49,6 +48,14 @@ public class SelfRegisteredSlaveRetentionStrategy extends CloudSlaveRetentionStr
         return 1;
     }
 
+    public String getCloudName() {
+        return cloudName;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
     @Override
     public void kill(Node node) throws IOException {
         LOGGER.info(format("Node %s will be killed now", node.getNodeDescription()));
@@ -82,16 +89,16 @@ public class SelfRegisteredSlaveRetentionStrategy extends CloudSlaveRetentionStr
     @VisibleForTesting
     void checkCloudExistence() {
         Cloud cloud = getCloud();
-        KubernetesCloudVerifier.checkCloudExistence(cloud, cloudName);
+        KubernetesCloudUtils.checkCloudExistence(cloud, cloudName);
     }
 
-    private void terminate(Slave node) throws IOException {
-        new SlaveTerminator(getCloud()).terminatePodSlave(node, namespace);
+    private void terminate(Slave slave) throws IOException {
+        new SlaveTerminator(getCloud()).terminatePodSlave(slave, namespace);
     }
 
     @VisibleForTesting
     KubernetesCloud getCloud() {
-        return (KubernetesCloud) Jenkins.getInstance().getCloud(cloudName);
+        return KubernetesCloudUtils.getCloud(cloudName);
     }
 
 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/SelfRegisteredSlaveRetentionStrategy.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/SelfRegisteredSlaveRetentionStrategy.java
@@ -2,25 +2,18 @@ package org.csanchez.jenkins.plugins.kubernetes;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import hudson.model.Computer;
 import hudson.model.Node;
+import hudson.model.Slave;
 import hudson.slaves.Cloud;
 import hudson.slaves.CloudSlaveRetentionStrategy;
-import hudson.slaves.OfflineCause;
 import hudson.util.TimeUnit2;
-import io.fabric8.kubernetes.api.model.DoneablePod;
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.dsl.PodResource;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
-import org.jvnet.localizer.Localizable;
-import org.jvnet.localizer.ResourceBundleHolder;
 
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static java.lang.String.format;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 
 /**
@@ -30,19 +23,19 @@ public class SelfRegisteredSlaveRetentionStrategy extends CloudSlaveRetentionStr
 
     private static final Logger LOGGER = Logger.getLogger(SelfRegisteredSlaveRetentionStrategy.class.getName());
 
-    /**
-     * The resource bundle reference
-     */
-    private final static ResourceBundleHolder HOLDER = ResourceBundleHolder.get(Messages.class);
-
     private final String cloudName;
+
     private final String namespace;
+
+    private final String podId;
+
     private final int maxMinutesIdle;
 
-    public SelfRegisteredSlaveRetentionStrategy(String cloudName, String namespace, int maxMinutesIdle) {
+    public SelfRegisteredSlaveRetentionStrategy(String cloudName, String namespace, String podId, int maxMinutesIdle) {
         Preconditions.checkArgument(isNotBlank(cloudName), "Cloud name needs to be defined");
         this.cloudName = cloudName;
         this.namespace = namespace;
+        this.podId = podId;
         this.maxMinutesIdle = maxMinutesIdle;
     }
 
@@ -57,80 +50,48 @@ public class SelfRegisteredSlaveRetentionStrategy extends CloudSlaveRetentionStr
     }
 
     @Override
-    protected void kill(Node node) throws IOException {
-        LOGGER.info("Node " + node.getNodeDescription() + " will be killed now");
-        if (canTerminate(node)) {
-            terminate(node);
+    public void kill(Node node) throws IOException {
+        LOGGER.info(format("Node %s will be killed now", node.getNodeDescription()));
+        Slave slave = (Slave) node;
+        if (canTerminate(slave)) {
+            terminate(slave);
         }
     }
 
     @VisibleForTesting
-    boolean canTerminate(Node node) {
-        String name = node.getNodeName();
-        LOGGER.log(Level.FINE, "Checking if can terminate Kubernetes instance for slave {0}", name);
-
-        Computer computer = getNodeComputer(node);
-        if (computer == null) {
-            LOGGER.log(Level.SEVERE, "Computer for slave is null: {0}", name);
-            return false;
-        }
-
-        Cloud cloud = getCloud();
-        if (!(cloud instanceof KubernetesCloud)) {
-            LOGGER.log(Level.SEVERE, "Slave cloud is not a KubernetesCloud, something is very wrong: {0}", name);
-            return false;
-        }
-        return true;
-    }
-
-    @VisibleForTesting
-    void terminate(Node node) throws IOException {
-        String name = node.getNodeName();
+    boolean canTerminate(Slave slave) {
+        String slaveNodeName = slave.getNodeName();
         try {
-            Cloud cloud = getCloud();
-            KubernetesClient client = ((KubernetesCloud) cloud).connect();
-            deletePod(name, client);
-            Computer computer = getNodeComputer(node);
-            computer.disconnect(OfflineCause.create(new Localizable(HOLDER, "offline")));
-            LOGGER.log(Level.INFO, "Disconnected computer {0}", name);
-        } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "Failed to terminate pod for slave " + name, e);
-        }
-    }
+            // Double-checking if it's the same slave - otherwise the retention strategy shouldn't apply
+            KubernetesSlaveUtils.checkSlaveName(slaveNodeName, podId);
 
-    // Have to have it in a separate method for tests, as toComputer() is final and can't be mocked
-    @VisibleForTesting
-    Computer getNodeComputer(Node node) {
-        return node.toComputer();
-    }
-
-    @VisibleForTesting
-    Cloud getCloud() {
-        return Jenkins.getInstance().getCloud(cloudName);
-    }
-
-    @VisibleForTesting
-    void deletePod(String name, KubernetesClient client) {
-        String podName = getPodName(name);
-        PodResource<Pod, DoneablePod> pods = client.pods().inNamespace(namespace).withName(podName);
-        Boolean deletionResult = pods.delete();
-        if (deletionResult == null) {
-            LOGGER.log(Level.SEVERE, "Pod {0} was not found in namespace {1}", new Object[] {podName, namespace});
-        } else if (!deletionResult) {
-            LOGGER.log(Level.SEVERE, "Failed to delete pod {0} from namespace {1}", new Object[] {podName, namespace});
-        } else {
-            LOGGER.log(Level.INFO, "Terminated Kubernetes instance for slave {0}", name);
+            LOGGER.log(Level.FINE, "Checking if can terminate Kubernetes instance for slave {0}", slaveNodeName);
+            checkSlaveComputer(slave);
+            checkCloudExistence();
+            return true;
+        } catch (CloudEntityVerificationException e) {
+            return false;
         }
     }
 
     @VisibleForTesting
-    static String getPodName(String nodeName) {
-        if (StringUtils.countMatches(nodeName, "-") <=1 ) {
-            return nodeName;
-        }
-        // TODO: self-registered slaves should also have the name == pod name
-        // As per contract for self-registered slaves, names should at least begin with pod name
-        return nodeName.substring(0, nodeName.lastIndexOf('-'));
+    void checkSlaveComputer(Slave slave) {
+        KubernetesSlaveUtils.checkSlaveComputer(slave);
+    }
+
+    @VisibleForTesting
+    void checkCloudExistence() {
+        Cloud cloud = getCloud();
+        KubernetesCloudVerifier.checkCloudExistence(cloud, cloudName);
+    }
+
+    private void terminate(Slave node) throws IOException {
+        new SlaveTerminator(getCloud()).terminatePodSlave(node, namespace);
+    }
+
+    @VisibleForTesting
+    KubernetesCloud getCloud() {
+        return (KubernetesCloud) Jenkins.getInstance().getCloud(cloudName);
     }
 
 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/SlaveTerminator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/SlaveTerminator.java
@@ -1,0 +1,79 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import com.google.common.annotations.VisibleForTesting;
+import hudson.model.Computer;
+import hudson.model.Slave;
+import hudson.slaves.OfflineCause;
+import io.fabric8.kubernetes.api.model.DoneablePod;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.PodResource;
+import org.jvnet.localizer.Localizable;
+import org.jvnet.localizer.ResourceBundleHolder;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static java.lang.String.format;
+
+/**
+ * @author <a href="mailto:kirill.shepitko@gmail.com">Kirill Shepitko</a>
+ */
+public class SlaveTerminator {
+
+    /**
+     * The resource bundle reference
+     */
+    private final static ResourceBundleHolder HOLDER = ResourceBundleHolder.get(Messages.class);
+
+    private static final Logger LOGGER = Logger.getLogger(KubernetesSlaveUtils.class.getName());
+
+    private final KubernetesCloud cloud;
+
+    public SlaveTerminator(KubernetesCloud cloud) {
+        this.cloud = cloud;
+    }
+
+    public boolean terminatePodSlave(Slave slave, String namespace) {
+        String slaveName = slave.getNodeName();
+        try {
+            KubernetesClient client = cloud.connect();
+            boolean deleted = deletePod(client, namespace, slaveName);
+            if (deleted) {
+                Computer computer = getSlaveComputer(slave);
+                if (computer != null) {
+                    computer.disconnect(OfflineCause.create(new Localizable(HOLDER, "offline")));
+                    LOGGER.log(Level.INFO, "Disconnected computer {0}", slaveName);
+                }
+                LOGGER.log(Level.INFO, format("Terminated Kubernetes instance for slave %s", slaveName));
+            }
+            return deleted;
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, format("Failed to terminate pod for slave %s", slaveName), e);
+            return false;
+        }
+    }
+
+    @VisibleForTesting
+    boolean deletePod(KubernetesClient client, String namespace, String podId) {
+        LOGGER.log(Level.INFO, "Will try to delete pod {0} to remove slave", new Object[] { podId });
+        PodResource<Pod, DoneablePod> pods = client.pods().inNamespace(namespace).withName(podId);
+        Boolean deletionResult = pods.delete();
+        if (deletionResult == null) {
+            String msg = format("Pod %s was not found in namespace %s", podId, namespace);
+            LOGGER.log(Level.SEVERE, msg);
+            throw new KubernetesSlaveException(msg);
+        } else if (!deletionResult) {
+            String msg = format("Failed to delete pod %s from namespace %s", podId, namespace);
+            LOGGER.log(Level.SEVERE, msg);
+            return false;
+        }
+        return true;
+    }
+
+    // Have to have it in a separate method for tests, as toComputer() is final and can't be mocked
+    @VisibleForTesting
+    Computer getSlaveComputer(Slave slave) {
+        return slave.toComputer();
+    }
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/SlaveTerminator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/SlaveTerminator.java
@@ -45,7 +45,7 @@ public class SlaveTerminator {
                     computer.disconnect(OfflineCause.create(new Localizable(HOLDER, "offline")));
                     LOGGER.log(Level.INFO, "Disconnected computer {0}", slaveName);
                 }
-                LOGGER.log(Level.INFO, format("Terminated Kubernetes instance for slave %s", slaveName));
+                LOGGER.log(Level.INFO, format("Terminated Kubernetes pod for slave %s", slaveName));
             }
             return deleted;
         } catch (Exception e) {

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/help-selfRegisteringSlave.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/help-selfRegisteringSlave.html
@@ -1,3 +1,3 @@
 <p>Check if image represents an agent that takes care of registering itself as a slave on master (e.g., in case of <b>Jenkins Swarm</b> client). False by default.</p>
-<p>In order for plugin to detect such slave, ensure its name at least starts with Pod ID</p>
-<p>Don't check if image represents a simple JNLP slave</p>
+<p>In order for plugin to detect such slave, <b>ensure its name is equal to Pod ID</b></p>
+<p>Don't check this checkbox if image represents a simple JNLP slave</p>

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/SelfRegisteredSlaveNodeListenerTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/SelfRegisteredSlaveNodeListenerTest.java
@@ -1,6 +1,7 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
 import hudson.model.Node;
+import hudson.model.Slave;
 import hudson.slaves.AbstractCloudSlave;
 import hudson.slaves.CloudRetentionStrategy;
 import org.junit.Before;
@@ -31,29 +32,29 @@ public class SelfRegisteredSlaveNodeListenerTest {
     private Node simpleNode;
 
     @Mock
-    private AbstractCloudSlave cloudSlave;
+    private AbstractCloudSlave differentSlave;
 
     @Before
     public void setUp() throws IOException {
-        doNothing().when(unit).kill(any(SelfRegisteredSlaveRetentionStrategy.class), any(Node.class));
+        doNothing().when(unit).kill(any(SelfRegisteredSlaveRetentionStrategy.class), any(Slave.class));
     }
 
     @Test
     public void shouldKillOnlySelfRegisteredSlaves() throws Exception {
         unit.onDeleted(simpleNode);
-        verify(unit, never()).kill(any(SelfRegisteredSlaveRetentionStrategy.class), any(Node.class));
+        verify(unit, never()).kill(any(SelfRegisteredSlaveRetentionStrategy.class), any(Slave.class));
 
-        unit.onDeleted(cloudSlave);
-        verify(unit, never()).kill(any(SelfRegisteredSlaveRetentionStrategy.class), any(Node.class));
+        unit.onDeleted(differentSlave);
+        verify(unit, never()).kill(any(SelfRegisteredSlaveRetentionStrategy.class), any(Slave.class));
 
-        when(cloudSlave.getRetentionStrategy()).thenReturn(new CloudRetentionStrategy(0));
-        unit.onDeleted(cloudSlave);
-        verify(unit, never()).kill(any(SelfRegisteredSlaveRetentionStrategy.class), any(Node.class));
+        when(differentSlave.getRetentionStrategy()).thenReturn(new CloudRetentionStrategy(0));
+        unit.onDeleted(differentSlave);
+        verify(unit, never()).kill(any(SelfRegisteredSlaveRetentionStrategy.class), any(Slave.class));
 
         SelfRegisteredSlaveRetentionStrategy strategy = new SelfRegisteredSlaveRetentionStrategy("strategy", null, null, 0);
-        when(cloudSlave.getRetentionStrategy()).thenReturn(strategy);
-        unit.onDeleted(cloudSlave);
-        verify(unit).kill(strategy, cloudSlave);
+        when(differentSlave.getRetentionStrategy()).thenReturn(strategy);
+        unit.onDeleted(differentSlave);
+        verify(unit).kill(strategy, differentSlave);
     }
 
 }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/SelfRegisteredSlaveNodeListenerTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/SelfRegisteredSlaveNodeListenerTest.java
@@ -1,0 +1,59 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import hudson.model.Node;
+import hudson.slaves.AbstractCloudSlave;
+import hudson.slaves.CloudRetentionStrategy;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author <a href="mailto:kirill.shepitko@gmail.com">Kirill Shepitko</a>
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SelfRegisteredSlaveNodeListenerTest {
+
+    @Spy
+    private SelfRegisteredSlaveNodeListener unit;
+
+    @Mock
+    private Node simpleNode;
+
+    @Mock
+    private AbstractCloudSlave cloudSlave;
+
+    @Before
+    public void setUp() throws IOException {
+        doNothing().when(unit).kill(any(SelfRegisteredSlaveRetentionStrategy.class), any(Node.class));
+    }
+
+    @Test
+    public void shouldKillOnlySelfRegisteredSlaves() throws Exception {
+        unit.onDeleted(simpleNode);
+        verify(unit, never()).kill(any(SelfRegisteredSlaveRetentionStrategy.class), any(Node.class));
+
+        unit.onDeleted(cloudSlave);
+        verify(unit, never()).kill(any(SelfRegisteredSlaveRetentionStrategy.class), any(Node.class));
+
+        when(cloudSlave.getRetentionStrategy()).thenReturn(new CloudRetentionStrategy(0));
+        unit.onDeleted(cloudSlave);
+        verify(unit, never()).kill(any(SelfRegisteredSlaveRetentionStrategy.class), any(Node.class));
+
+        SelfRegisteredSlaveRetentionStrategy strategy = new SelfRegisteredSlaveRetentionStrategy("strategy", null, null, 0);
+        when(cloudSlave.getRetentionStrategy()).thenReturn(strategy);
+        unit.onDeleted(cloudSlave);
+        verify(unit).kill(strategy, cloudSlave);
+    }
+
+}

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/SelfRegisteringSlaveCallbackTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/SelfRegisteringSlaveCallbackTest.java
@@ -1,0 +1,79 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import hudson.model.Label;
+import hudson.model.Slave;
+import hudson.slaves.SlaveComputer;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodStatus;
+import jenkins.model.Jenkins;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author <a href="mailto:kirill.shepitko@gmail.com">Kirill Shepitko</a>
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SelfRegisteringSlaveCallbackTest {
+
+    private static final String POD_ID = "podId";
+    
+    private static final String NAMESPACE = "namespace";
+
+    private static final String SLAVE_NAME = "mySlave";
+
+    @Mock
+    private KubernetesCloud cloud;
+
+    @Mock
+    private Slave slave;
+
+    @Mock
+    private SlaveComputer computer;
+
+    @Mock
+    private Pod pod;
+
+    @Mock
+    private PodStatus podStatus;
+
+    @Mock
+    private Jenkins jenkins;
+
+    @Mock
+    private PodTemplate podTemplate;
+
+    private KubernetesCloud.SelfRegisteringSlaveCallback unit;
+
+    @Before
+    public void init() throws Exception {
+        unit = new KubernetesCloud("cloudName").new SelfRegisteringSlaveCallback(cloud, podTemplate, mock(Label.class));
+        unit = spy(unit);
+        doReturn(jenkins).when(unit).jenkins();
+        doReturn(SLAVE_NAME).when(slave).getDisplayName();
+    }
+
+    @Test
+    public void waitForSlaveToConnect() throws Exception {
+        doReturn(3).when(podTemplate).getSlaveConnectTimeout();
+        // First don't find, then find
+        doReturn(null).doReturn(slave).when(jenkins).getNode(POD_ID);
+
+        SlaveOperationDetails slaveOperationDetails = unit.waitForSlaveToConnect(POD_ID, NAMESPACE);
+        Slave slave = slaveOperationDetails.getSlave();
+        assertThat(slave).isNotNull();
+        assertThat(slave.getDisplayName()).isEqualTo(SLAVE_NAME);
+
+        verify(unit, times(2)).findSelfRegisteredSlaveByPodId(POD_ID);
+    }
+
+}

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/SlaveTerminatorTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/SlaveTerminatorTest.java
@@ -1,0 +1,121 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import hudson.model.Computer;
+import hudson.model.Slave;
+import hudson.slaves.OfflineCause;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.PodResource;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author <a href="mailto:kirill.shepitko@gmail.com">Kirill Shepitko</a>
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SlaveTerminatorTest {
+
+    private static final String NODE_NAME = "nodeName";
+
+    private static final String BAD_NODE = "badBadNode";
+
+    private static final String NAMESPACE = "namespace";
+
+    @Mock
+    private Slave slave;
+
+    @Mock
+    private Computer computer;
+
+    @Mock
+    private KubernetesCloud cloud;
+
+    @Mock
+    private PodResource goodPodResource;
+
+    @Mock
+    private PodResource badPodResource;
+
+    @Mock
+    private NonNamespaceOperation nonNamespaceOperation;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private KubernetesClient client;
+
+    @Spy
+    @InjectMocks
+    private SlaveTerminator unit;
+
+    @Before
+    public void setUp() {
+        doReturn(NODE_NAME).when(slave).getNodeName();  // To have a better looking logging
+    }
+
+    @Test
+    public void shouldHandleErrorsOnTerminate() throws Exception {
+        doReturn(client).doThrow(new RuntimeException()).when(cloud).connect();
+        doReturn(false).when(unit).deletePod(client, NAMESPACE, NODE_NAME);
+
+        assertThat(unit.terminatePodSlave(slave, NAMESPACE)).isFalse();
+        assertThat(unit.terminatePodSlave(slave, NAMESPACE)).isFalse();
+    }
+
+    @Test
+    public void terminateNodeHappyPath() throws Exception {
+        doReturn(computer).when(unit).getSlaveComputer(eq(slave));
+        doReturn(true).when(unit).deletePod(client, NAMESPACE, NODE_NAME);
+        doReturn(client).when(cloud).connect();
+        assertThat(unit.terminatePodSlave(slave, NAMESPACE)).isTrue();
+        verifyDeletePodAttempts(1);
+        verifyDisconnectComputerAttempts(1);
+    }
+
+    @Test
+    public void shouldReturnDeletedStatus() throws Exception {
+        when(client.pods().inNamespace(NAMESPACE)).thenReturn(nonNamespaceOperation);
+        when(nonNamespaceOperation.withName(NODE_NAME)).thenReturn(goodPodResource);
+        when(goodPodResource.delete()).thenReturn(true);
+
+        when(nonNamespaceOperation.withName(BAD_NODE)).thenReturn(badPodResource);
+        when(badPodResource.delete()).thenReturn(false);
+
+        assertThat(unit.deletePod(client, NAMESPACE, NODE_NAME)).isTrue();
+        assertThat(unit.deletePod(client, NAMESPACE, BAD_NODE)).isFalse();
+    }
+
+    @Test
+    public void shouldThrowExceptionOnMissingPod() throws Exception {
+        when(client.pods().inNamespace(NAMESPACE)).thenReturn(nonNamespaceOperation);
+        when(nonNamespaceOperation.withName(BAD_NODE)).thenReturn(badPodResource);
+        when(badPodResource.delete()).thenReturn(null);
+
+        assertThatThrownBy(() -> unit.deletePod(client, NAMESPACE, BAD_NODE))
+                .isInstanceOf(KubernetesSlaveException.class)
+                .hasMessageContaining(format("Pod %s was not found in namespace %s", BAD_NODE, NAMESPACE));
+    }
+
+    private void verifyDisconnectComputerAttempts(int expectedCount) {
+        verify(computer, times(expectedCount)).disconnect(any(OfflineCause.class));
+    }
+
+    private void verifyDeletePodAttempts(int expectedCount) {
+        verify(unit, times(expectedCount)).deletePod(eq(client), anyString(), anyString());
+    }
+}


### PR DESCRIPTION
* Name of self-registered slave should be equal to its K8s pod name
* Added a NodeListener for self-registered slaves to delete pod on manual slave deletion ("Delete agent") from Jenkins
* Extracted slave pod deletion logic into a helper class for reuse
* Refactored call() in KubernetesCloud callbacks to extract common code