### PR TITLE
Doc update and code cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The `containerTemplate` is a template of container that will be added to the pod
 
 * **name** The name of the container.
 * **image** The image of the container.
+* **slaveImage** Flag to mark whether the current image represents a Jenkins slave.
 * **envVars** Environment variables that are applied to the container **(supplementing and overriding env vars that are set on pod level)**.
 * **command** The command the container will execute.
 * **args** The arugments passed to the command.
@@ -109,7 +110,7 @@ podTemplate(label: 'anotherpod', inheritFrom: 'mypod'  containers: [
     containerTemplate(name: 'maven', image: 'maven:3.3.9-jdk-7-alpine')    
   ]) {
       
-      //Let's not repeat ourselves and ommit this part
+      //Let's not repeat ourselves and omit this part
 }
 ```
 
@@ -222,11 +223,23 @@ annotations: [
 
 Multiple containers can be defined in a pod.
 One of them is automatically created with name `jnlp`, and runs the Jenkins JNLP agent service, with args `${computer.jnlpmac} ${computer.name}`,
-and will be the container acting as Jenkins agent. It can ve overridden by defining a container with the same name.
+and will be the container acting as Jenkins agent. It can be overridden by defining a container with the same name. 
+Alternatively, if you have a custom agent image, just check `A Jenkins agent image` check box. 
 
 Other containers must run a long running process, so the container does not exit. If the default entrypoint or command
 just runs something and exit then it should be overriden with something like `cat` with `ttyEnabled: true`.
 
+Please note that you are allowed to have only one agent container per pod template.
+
+# Self-registering agents
+
+If your slave container is capable of self-registering itself in Jenkins as a slave when the pod starts (for instance, if you use a 
+[Jenkins Swarm plugin](https://github.com/jenkinsci/swarm-plugin) along with the Kubernetes plugin, 
+and your slave is based on a client for it), this is supported - just put a tick in `Self-registering agent`
+check box that appears in `Container template` below `A Jenkins agent image` check box if you check it. 
+This is needed to prevent the creation of the "default" node in Jenkins along with yours.
+
+In order for plugin to find your self-registering agent, you need to make sure its name is equal to the pod ID.
 
 # Over provisioning flags
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/SelfRegisteredSlaveNodeListener.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/SelfRegisteredSlaveNodeListener.java
@@ -12,6 +12,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
+ * <p>Deletes the pod with self-registering slave from Kubernetes.</p>
+ * <p>Actioned by retention strategy or manual slave deletion.</p>
+ *
  * @author <a href="mailto:kirill.shepitko@gmail.com">Kirill Shepitko</a>
  */
 @Extension
@@ -21,7 +24,6 @@ public class SelfRegisteredSlaveNodeListener extends NodeListener {
 
     @Override
     protected void onDeleted(@Nonnull Node node) {
-        LOGGER.log(Level.INFO, "Node {0} (labels - {1}) was deleted", new Object[] {node, node.getLabelString()});
         if (node instanceof Slave) {
             Slave slave = (Slave) node;
             RetentionStrategy retentionStrategy = slave.getRetentionStrategy();
@@ -34,7 +36,7 @@ public class SelfRegisteredSlaveNodeListener extends NodeListener {
     @VisibleForTesting
     void kill(SelfRegisteredSlaveRetentionStrategy retentionStrategy, @Nonnull Slave slave) {
         String podName = slave.getNodeName();
-        LOGGER.log(Level.INFO, "Going to delete pod {0}", podName);
+        LOGGER.log(Level.FINE, "Going to delete pod {0}", podName);
 
         String cloudName = retentionStrategy.getCloudName();
         String namespace = retentionStrategy.getNamespace();

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/SlaveTerminator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/SlaveTerminator.java
@@ -26,7 +26,7 @@ public class SlaveTerminator {
      */
     private final static ResourceBundleHolder HOLDER = ResourceBundleHolder.get(Messages.class);
 
-    private static final Logger LOGGER = Logger.getLogger(KubernetesSlaveUtils.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(SlaveTerminator.class.getName());
 
     private final KubernetesCloud cloud;
 
@@ -45,7 +45,7 @@ public class SlaveTerminator {
                     computer.disconnect(OfflineCause.create(new Localizable(HOLDER, "offline")));
                     LOGGER.log(Level.INFO, "Disconnected computer {0}", slaveName);
                 }
-                LOGGER.log(Level.INFO, format("Terminated Kubernetes pod for slave %s", slaveName));
+                LOGGER.log(Level.INFO, "Terminated Kubernetes pod for slave {0}", slaveName);
             }
             return deleted;
         } catch (Exception e) {
@@ -56,7 +56,7 @@ public class SlaveTerminator {
 
     @VisibleForTesting
     boolean deletePod(KubernetesClient client, String namespace, String podId) {
-        LOGGER.log(Level.INFO, "Will try to delete pod {0} to remove slave", new Object[] { podId });
+        LOGGER.log(Level.INFO, "Will try to delete pod {0} in namespace {1} to remove slave", new Object[] { podId, namespace });
         PodResource<Pod, DoneablePod> pods = client.pods().inNamespace(namespace).withName(podId);
         Boolean deletionResult = pods.delete();
         if (deletionResult == null) {
@@ -64,8 +64,7 @@ public class SlaveTerminator {
             LOGGER.log(Level.SEVERE, msg);
             throw new KubernetesSlaveException(msg);
         } else if (!deletionResult) {
-            String msg = format("Failed to delete pod %s from namespace %s", podId, namespace);
-            LOGGER.log(Level.SEVERE, msg);
+            LOGGER.log(Level.SEVERE, "Failed to delete pod {0} from namespace {1}", new Object[] { podId, namespace });
             return false;
         }
         return true;

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/config.jelly
@@ -22,8 +22,8 @@
     <f:textbox default="/home/jenkins"/>
   </f:entry>
 
-  <f:optionalBlock name="slaveImage" inline="true" title="A Jenkins slave image" checked="${instance.slaveImage}">
-    <f:entry field="selfRegisteringSlave" title="${%Self-registering slave}">
+  <f:optionalBlock name="slaveImage" inline="true" title="A Jenkins agent image" checked="${instance.slaveImage}">
+    <f:entry field="selfRegisteringSlave" title="${%Self-registering agent}">
       <f:checkbox/>
     </f:entry>
   </f:optionalBlock>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/help-slaveImage.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/help-slaveImage.html
@@ -1,1 +1,1 @@
-Check if image represents a Jenkins slave (e.g., JNLP slave)
+Check if image represents a Jenkins agent (e.g., JNLP agent)

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/SimpleProvisioningCallbackTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/SimpleProvisioningCallbackTest.java
@@ -67,8 +67,9 @@ public class SimpleProvisioningCallbackTest {
         unit = spy(unit);
         doReturn(jenkins).when(unit).jenkins();
         doReturn(POD_ID).when(unit).getPodId(pod);
+        doReturn(NAMESPACE).when(unit).getPodNameSpace(pod);
         doReturn(pod).when(unit).getPodByNamespaceAndPodId(eq(NAMESPACE), eq(POD_ID));
-        doNothing().when(unit).logLastSlaveContainerLines(eq(pod), eq(POD_ID));
+        doNothing().when(unit).logLastSlaveContainerLines(eq(pod));
     }
 
     @Test


### PR DESCRIPTION
* Removed pod deletion from SelfRegisteredSlaveRetentionStrategy, as it's already done by SelfRegisteredSlaveNodeListener
* Fixed pod data not being up-to-date in logs
* Renamed slaves to agents in UI
* Removed excessive slaveName passing in KubernetesCloud
* Minor improvements
* Documented the self-registering and custom agent aspects in README.md
* Deleted extra logging